### PR TITLE
Make install command more explicite

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A python script to convert Wordpress XML dump to a set of plain text/[markdown](
 
 The script could be installed by command:
 
-	pip install -e git+git://github.com/dreikanter/wp2md#egg=wp2md
+	pip install -e "git+git://github.com/dreikanter/wp2md#egg=wp2md"
 
 It will install wp2md and the following dependencies:
 


### PR DESCRIPTION
For some reason, Zsh failed to interpret the install command unless I quoted the repository url. Probably just a fluke of Zsh trying too hard to be clever, but I figure it can't hurt to be more explicit.
