### PR TITLE
Installation fails on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author=wp2md.authoring.__author__,
     author_email=wp2md.authoring.__email__,
     url=wp2md.authoring.__url__,
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding="utf8").read(),
     platforms=['any'],
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
setup.py opens README.md without an encoding specified, which appears to default to 1252 on Windows. This causes the installation to fail.

I've updated setup.py to specify utf8 encoding, which fixes the issue.