### PR TITLE
Fixes setup fail due to Python2's encoding, issue #17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author=wp2md.authoring.__author__,
     author_email=wp2md.authoring.__email__,
     url=wp2md.authoring.__url__,
-    long_description=open('README.md', encoding="utf8").read(),
+    long_description=open('README.md',"rb").read().decode('utf8'),
     platforms=['any'],
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Python has changed the way `open().read()` decodes strings. 
The `encoding="utf8"` parameter is not backwards compatible to Python 2, but `open('README.md',"rb").read().decode('utf8')` should work both in Python 2 and 3.

The fix worked. Tested on both in Linux(Python 2.7.11), and Windows 8.1(Python 2.7.11). Also on Python 2.7.6(Ubuntu linux64)

Related:  https://github.com/aerkalov/ebooklib/issues/75