### PR TITLE
Work around the problem of content truncation.

### DIFF
--- a/wp2md/html2text.py
+++ b/wp2md/html2text.py
@@ -613,7 +613,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                 if not self.list:
                     bq += "    "
                 #else: list content is already partially indented
-                for i in xrange(len(self.list)):
+                for i in range(len(self.list)):
                     bq += "    "
                 data = data.replace("\n", "\n"+bq)
 

--- a/wp2md/wp2md.py
+++ b/wp2md/wp2md.py
@@ -599,18 +599,21 @@ class CustomParser:
             self.subj = None
 
     def data(self, data):
+        """This can be called multiple times for one field."""
         if self.subj:
             if self.cur_section() == 'comment':
                 self.cmnt[self.subj] = data
 
             elif self.cur_section() == 'item':
-                self.item[self.subj] = data
+                if self.subj in self.item:
+                    self.item[self.subj] += data
+                else:
+                    self.item[self.subj] = data
 
             elif self.cur_section() == 'channel':
                 self.channel[self.subj] = data
                 if self.subj == 'base_site_url':
                     store_base_url(self.channel)
-            self.subj = None
 
     def start_section(self, what):
         self.section_stack.append(what)


### PR DESCRIPTION
https://github.com/dreikanter/wp2md/issues/19

I don't know if this is the right solution, but it worked for me. The problem is that data() can be called multiple times for one item, so setting self.subj to None had to be removed. Data from multiple data() calls are concatenated.

I also had to edit text2html, because it didn't work with Python 3.4 (there is no xrange).
