### PR TITLE
Fix None description issue

### DIFF
--- a/wp2md/wp2md.py
+++ b/wp2md/wp2md.py
@@ -379,7 +379,10 @@ def html2md(html):
 
 def generate_toc(meta, items):
     """Generates MD-formatted index page."""
-    content = meta.get('description', '') + '\n\n'
+    if not meta.get('description', ''):
+        content = '\n\n'
+    else:
+        content = meta.get('description', '') + '\n\n'
     for item in items:
         content += str_t("* {post_date}: [{title}]({link})\n").format(**item)
     return content


### PR DESCRIPTION
Fix type error when meta.get('description', '') returns None.
![typeerror](https://cloud.githubusercontent.com/assets/24546024/22826196/1fd7a208-efcc-11e6-874a-5b9cd484b0e8.png)